### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/compile-configs.yml
+++ b/.github/workflows/compile-configs.yml
@@ -37,7 +37,7 @@ jobs:
       id: build_configs
       run: |
         if [ "$BOARD" = V4 ]; then BOARDTMP=v4.2.2; else BOARDTMP=v4.2.7; fi;
-        echo "::set-output name=filename::E3V2-Default-${BOARDTMP}.bin"
+        echo "filename=E3V2-Default-${BOARDTMP}.bin" >> $GITHUB_OUTPUT
         cp Configuration\ Files/E3V2\ Templates/Default-NoProbe/Configuration.h Marlin/Configuration.h
         cp Configuration\ Files/E3V2\ Templates/Default-NoProbe/Configuration_adv.h Marlin/Configuration_adv.h
         sed -i "s/#define MOTHERBOARD.*/#define MOTHERBOARD BOARD_CREALITY_$BOARD/g" Marlin/Configuration.h
@@ -93,7 +93,7 @@ jobs:
       run: |
         if ($HS); then HSTMP=-HS; else HSTMP=; fi;
         if [ "$BOARD" = V4 ]; then BOARDTMP=v4.2.2; else BOARDTMP=v4.2.7; fi;
-        echo "::set-output name=filename::E3V2-BLTouch-${GRID}x${GRID}${HSTMP}-${BOARDTMP}.bin"
+        echo "filename=E3V2-BLTouch-${GRID}x${GRID}${HSTMP}-${BOARDTMP}.bin" >> $GITHUB_OUTPUT
         cp Configuration\ Files/E3V2\ Templates/BLTouch-3x3/Configuration.h Marlin/Configuration.h
         cp Configuration\ Files/E3V2\ Templates/BLTouch-3x3/Configuration_adv.h Marlin/Configuration_adv.h
         sed -i "s/#define MOTHERBOARD.*/#define MOTHERBOARD BOARD_CREALITY_$BOARD/g" Marlin/Configuration.h
@@ -152,7 +152,7 @@ jobs:
       id: build_configs
       run: |
         if [ "$BOARD" = V4 ]; then BOARDTMP=v4.2.2; else BOARDTMP=v4.2.7; fi;
-        echo "::set-output name=filename::E3V2-ManualMesh-${GRID}x${GRID}-${BOARDTMP}.bin"
+        echo "filename=E3V2-ManualMesh-${GRID}x${GRID}-${BOARDTMP}.bin" >> $GITHUB_OUTPUT
         cp Configuration\ Files/E3V2\ Templates/ManualMesh-3x3/Configuration.h Marlin/Configuration.h
         cp Configuration\ Files/E3V2\ Templates/ManualMesh-3x3/Configuration_adv.h Marlin/Configuration_adv.h
         sed -i "s/#define MOTHERBOARD.*/#define MOTHERBOARD BOARD_CREALITY_$BOARD/g" Marlin/Configuration.h
@@ -210,7 +210,7 @@ jobs:
       run: |
         if ($HS); then HSTMP=-HS; else HSTMP=; fi;
         if [ "$BOARD" = V4 ]; then BOARDTMP=v4.2.2; else BOARDTMP=v4.2.7; fi;
-        echo "::set-output name=filename::E3V2-UBL-BLTouch-${GRID}x${GRID}${HSTMP}-${BOARDTMP}.bin"
+        echo "filename=E3V2-UBL-BLTouch-${GRID}x${GRID}${HSTMP}-${BOARDTMP}.bin" >> $GITHUB_OUTPUT
         cp Configuration\ Files/E3V2\ Templates/UBL-BLTouch-10x10/Configuration.h Marlin/Configuration.h
         cp Configuration\ Files/E3V2\ Templates/UBL-BLTouch-10x10/Configuration_adv.h Marlin/Configuration_adv.h
         sed -i "s/#define MOTHERBOARD.*/#define MOTHERBOARD BOARD_CREALITY_$BOARD/g" Marlin/Configuration.h
@@ -269,7 +269,7 @@ jobs:
       id: build_configs
       run: |
         if [ "$BOARD" = V4 ]; then BOARDTMP=v4.2.2; else BOARDTMP=v4.2.7; fi;
-        echo "::set-output name=filename::E3V2-UBL-NoProbe-${GRID}x${GRID}-${BOARDTMP}.bin"
+        echo "filename=E3V2-UBL-NoProbe-${GRID}x${GRID}-${BOARDTMP}.bin" >> $GITHUB_OUTPUT
         cp Configuration\ Files/E3V2\ Templates/UBL-NoProbe-3x3/Configuration.h Marlin/Configuration.h
         cp Configuration\ Files/E3V2\ Templates/UBL-NoProbe-3x3/Configuration_adv.h Marlin/Configuration_adv.h
         sed -i "s/#define MOTHERBOARD.*/#define MOTHERBOARD BOARD_CREALITY_$BOARD/g" Marlin/Configuration.h

--- a/.github/workflows/compile-configs.yml
+++ b/.github/workflows/compile-configs.yml
@@ -37,7 +37,7 @@ jobs:
       id: build_configs
       run: |
         if [ "$BOARD" = V4 ]; then BOARDTMP=v4.2.2; else BOARDTMP=v4.2.7; fi;
-        echo "filename=E3V2-Default-${BOARDTMP}.bin" >> $GITHUB_OUTPUT
+        echo "filename=E3V2-Default-${BOARDTMP}.bin" >> "$GITHUB_OUTPUT"
         cp Configuration\ Files/E3V2\ Templates/Default-NoProbe/Configuration.h Marlin/Configuration.h
         cp Configuration\ Files/E3V2\ Templates/Default-NoProbe/Configuration_adv.h Marlin/Configuration_adv.h
         sed -i "s/#define MOTHERBOARD.*/#define MOTHERBOARD BOARD_CREALITY_$BOARD/g" Marlin/Configuration.h
@@ -93,7 +93,7 @@ jobs:
       run: |
         if ($HS); then HSTMP=-HS; else HSTMP=; fi;
         if [ "$BOARD" = V4 ]; then BOARDTMP=v4.2.2; else BOARDTMP=v4.2.7; fi;
-        echo "filename=E3V2-BLTouch-${GRID}x${GRID}${HSTMP}-${BOARDTMP}.bin" >> $GITHUB_OUTPUT
+        echo "filename=E3V2-BLTouch-${GRID}x${GRID}${HSTMP}-${BOARDTMP}.bin" >> "$GITHUB_OUTPUT"
         cp Configuration\ Files/E3V2\ Templates/BLTouch-3x3/Configuration.h Marlin/Configuration.h
         cp Configuration\ Files/E3V2\ Templates/BLTouch-3x3/Configuration_adv.h Marlin/Configuration_adv.h
         sed -i "s/#define MOTHERBOARD.*/#define MOTHERBOARD BOARD_CREALITY_$BOARD/g" Marlin/Configuration.h
@@ -152,7 +152,7 @@ jobs:
       id: build_configs
       run: |
         if [ "$BOARD" = V4 ]; then BOARDTMP=v4.2.2; else BOARDTMP=v4.2.7; fi;
-        echo "filename=E3V2-ManualMesh-${GRID}x${GRID}-${BOARDTMP}.bin" >> $GITHUB_OUTPUT
+        echo "filename=E3V2-ManualMesh-${GRID}x${GRID}-${BOARDTMP}.bin" >> "$GITHUB_OUTPUT"
         cp Configuration\ Files/E3V2\ Templates/ManualMesh-3x3/Configuration.h Marlin/Configuration.h
         cp Configuration\ Files/E3V2\ Templates/ManualMesh-3x3/Configuration_adv.h Marlin/Configuration_adv.h
         sed -i "s/#define MOTHERBOARD.*/#define MOTHERBOARD BOARD_CREALITY_$BOARD/g" Marlin/Configuration.h
@@ -210,7 +210,7 @@ jobs:
       run: |
         if ($HS); then HSTMP=-HS; else HSTMP=; fi;
         if [ "$BOARD" = V4 ]; then BOARDTMP=v4.2.2; else BOARDTMP=v4.2.7; fi;
-        echo "filename=E3V2-UBL-BLTouch-${GRID}x${GRID}${HSTMP}-${BOARDTMP}.bin" >> $GITHUB_OUTPUT
+        echo "filename=E3V2-UBL-BLTouch-${GRID}x${GRID}${HSTMP}-${BOARDTMP}.bin" >> "$GITHUB_OUTPUT"
         cp Configuration\ Files/E3V2\ Templates/UBL-BLTouch-10x10/Configuration.h Marlin/Configuration.h
         cp Configuration\ Files/E3V2\ Templates/UBL-BLTouch-10x10/Configuration_adv.h Marlin/Configuration_adv.h
         sed -i "s/#define MOTHERBOARD.*/#define MOTHERBOARD BOARD_CREALITY_$BOARD/g" Marlin/Configuration.h
@@ -269,7 +269,7 @@ jobs:
       id: build_configs
       run: |
         if [ "$BOARD" = V4 ]; then BOARDTMP=v4.2.2; else BOARDTMP=v4.2.7; fi;
-        echo "filename=E3V2-UBL-NoProbe-${GRID}x${GRID}-${BOARDTMP}.bin" >> $GITHUB_OUTPUT
+        echo "filename=E3V2-UBL-NoProbe-${GRID}x${GRID}-${BOARDTMP}.bin" >> "$GITHUB_OUTPUT"
         cp Configuration\ Files/E3V2\ Templates/UBL-NoProbe-3x3/Configuration.h Marlin/Configuration.h
         cp Configuration\ Files/E3V2\ Templates/UBL-NoProbe-3x3/Configuration_adv.h Marlin/Configuration_adv.h
         sed -i "s/#define MOTHERBOARD.*/#define MOTHERBOARD BOARD_CREALITY_$BOARD/g" Marlin/Configuration.h


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


